### PR TITLE
Fix Issues #16 #42 #44 (GSoC'22)

### DIFF
--- a/assets/privacy_policy.md
+++ b/assets/privacy_policy.md
@@ -1,0 +1,17 @@
+# Privacy Policy
+
+We want to make sure you, as a Customer or Finder, understand what information we collect from you and why. We also want you to know about our information use practices so that you can make good decisions about how you use Bugheist.
+
+This Privacy Policy explains what information we collect from and about you, (collectively, "Your Information") and what we do with it.
+
+_Please read this Privacy Policy carefully._
+
+## Information Collection
+- __Direct Collection__
+    - When you create an account with Bugheist, you are required to provide us with profile information, including your name, company name (if applicable), username, password, and email address. Bugheist stores this information to help identify you when you log in.
+
+- __Indirect Collection__
+    - We receive some information automatically when you visit Bugheist. This includes information about the device, browser, and operating system you use when accessing our site and Services and your IP address. If you visit Bugheist when you are logged into your account, we also collect the user identification number we assign you when you open your account.
+
+- __Cookie Policy__
+    - When you log in to your account, Bugheist will place cookie(s) for the purpose of creating the session, knowing when you're logged in, and recognizing you as the same authenticated user across accounts. These cookie(s) contain an encrypted user identifier.

--- a/lib/data/models.dart
+++ b/lib/data/models.dart
@@ -29,14 +29,24 @@ class Results {
   final String id;
   final String description;
   final String screenshot;
-  Results(
-      {required this.id, required this.description, required this.screenshot});
+  final bool isOpen;
+  final DateTime createdOn;
+  Results({
+    required this.id,
+    required this.description,
+    required this.screenshot,
+    required this.isOpen,
+    required this.createdOn,
+  });
 
   factory Results.fromJson(Map<String, dynamic> parsedJson) {
     return Results(
-        id: parsedJson['id'].toString(),
-        description: parsedJson['description'],
-        screenshot: parsedJson['screenshot']);
+      id: parsedJson['id'].toString(),
+      description: parsedJson['description'],
+      screenshot: parsedJson['screenshot'],
+      isOpen: (parsedJson["status"] == "open") ? true : false,
+      createdOn: DateTime.parse(parsedJson["created"]),
+    );
   }
 }
 

--- a/lib/models/company_model.dart
+++ b/lib/models/company_model.dart
@@ -1,0 +1,28 @@
+class Company {
+  final String companyName;
+  final int openIssues;
+  final int closedIssues;
+  final DateTime lastModified;
+  final String logoLink;
+  final String topTester;
+
+  Company(
+    this.companyName,
+    this.openIssues,
+    this.closedIssues,
+    this.lastModified,
+    this.logoLink,
+    this.topTester,
+  );
+
+  factory Company.fromJson(Map<String, dynamic> parsedJson) {
+    return Company(
+      parsedJson["name"],
+      parsedJson["open"],
+      parsedJson["closed"],
+      DateTime.parse(parsedJson["modified"]),
+      parsedJson["logo"].toString(),
+      parsedJson["top"],
+    );
+  }
+}

--- a/lib/pages/company_scoreboard.dart
+++ b/lib/pages/company_scoreboard.dart
@@ -1,0 +1,203 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../services/api.dart';
+
+class CompanyScoreBoardPage extends StatefulWidget {
+  const CompanyScoreBoardPage({Key? key}) : super(key: key);
+
+  @override
+  State<CompanyScoreBoardPage> createState() => _CompanyScoreBoardPageState();
+}
+
+class _CompanyScoreBoardPageState extends State<CompanyScoreBoardPage> {
+  late Future _getObj;
+
+  CircleAvatar buildLogo(String partUrl) {
+    try {
+      if (partUrl == "")
+        return CircleAvatar(
+          foregroundColor: Colors.transparent,
+          // backgroundColor: Colors.transparent,
+          radius: 20,
+          child: Icon(
+            Icons.account_circle_outlined,
+            color: Color(0xFFDC4654),
+            size: 40,
+          ),
+        );
+      else
+        return CircleAvatar(
+          foregroundImage: NetworkImage(
+            "https://storage.googleapis.com/bhfiles/" + partUrl,
+          ),
+          radius: 20,
+        );
+    } on Exception {
+      return CircleAvatar(
+        foregroundColor: Colors.transparent,
+        backgroundColor: Colors.transparent,
+        child: Icon(
+          Icons.account_circle_outlined,
+          color: Colors.white,
+          size: 20,
+        ),
+      );
+    }
+  }
+
+  @override
+  void initState() {
+    var paginatedUrl = 'https://www.bugheist.com/api/v1/scoreboard/';
+    _getObj = ApiBackend().getScoreBoardData(paginatedUrl);
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Size size = MediaQuery.of(context).size;
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: Icon(
+            Icons.arrow_back_ios_new_rounded,
+          ),
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+        ),
+        title: Text("Company Scoreboard"),
+        backgroundColor: Color(0xFFDC4654),
+      ),
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            Container(
+              padding: EdgeInsets.symmetric(horizontal: 20),
+              width: size.width,
+              color: Theme.of(context).canvasColor,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    padding: EdgeInsets.fromLTRB(0, 12, 0, 12),
+                    child: Text(
+                      'Company Scoreboards',
+                      style: GoogleFonts.ubuntu(
+                        textStyle: TextStyle(
+                          color: Color(0xFF737373),
+                          fontSize: 25,
+                        ),
+                      ),
+                    ),
+                  ),
+                  Container(
+                    padding: EdgeInsets.fromLTRB(0, 0, 0, 16),
+                    child: Text(
+                      "These are the most active companies that are on BugHeist.",
+                      style: GoogleFonts.aBeeZee(
+                        textStyle: TextStyle(
+                          color: Color(0xFF737373),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Container(
+              height: size.height * 0.8,
+              padding: EdgeInsets.symmetric(horizontal: 20),
+              child: FutureBuilder(
+                future: _getObj,
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState == ConnectionState.done) {
+                    if (snapshot.hasError) {
+                      return Center(
+                        child: Text(
+                          'Something went wrong!',
+                          style: TextStyle(fontSize: 18),
+                        ),
+                      );
+                    } else if (snapshot.hasData) {
+                      final list = snapshot.data as List;
+                      return Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 0.0,
+                          vertical: 20.0,
+                        ),
+                        child: Material(
+                          color: Colors.transparent,
+                          child: ListView.builder(
+                            itemCount: list.length,
+                            itemBuilder: (context, index) {
+                              return ListTile(
+                                onTap: () {},
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: index == 0
+                                      ? BorderRadius.only(
+                                          topLeft: Radius.circular(10),
+                                          topRight: Radius.circular(15),
+                                        )
+                                      : index == list.length - 1
+                                          ? BorderRadius.only(
+                                              bottomLeft: Radius.circular(10),
+                                              bottomRight: Radius.circular(10),
+                                            )
+                                          : BorderRadius.only(
+                                              topLeft: Radius.circular(0),
+                                            ),
+                                ),
+                                tileColor: Color(0xFFE0E0E0),
+                                leading: buildLogo(list[index].logoLink),
+                                title: Text(
+                                  list[index].companyName,
+                                  style: GoogleFonts.ubuntu(
+                                    textStyle: TextStyle(
+                                      color: Color(0xFFDC4654),
+                                    ),
+                                  ),
+                                  maxLines: 6,
+                                ),
+                                subtitle: Text(
+                                  "Open: " +
+                                      list[index].openIssues.toString() +
+                                      "| Closed: " +
+                                      list[index].closedIssues.toString(),
+                                  style: GoogleFonts.aBeeZee(
+                                    textStyle: TextStyle(
+                                      color: Color(0xFF737373),
+                                      fontSize: 12,
+                                    ),
+                                  ),
+                                ),
+                                trailing: Text(
+                                  list[index].topTester.toString(),
+                                  style: GoogleFonts.ubuntu(
+                                    textStyle: TextStyle(
+                                      color: Color(0xFF737373),
+                                      fontSize: 15,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                      );
+                    }
+                  }
+                  return Center(
+                    child: CircularProgressIndicator(),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/components/appbar.dart
+++ b/lib/pages/components/appbar.dart
@@ -28,7 +28,7 @@ AppBar buildAppBar({required BuildContext context}) {
       )
     ],
     elevation: 0,
-    backgroundColor: Colors.transparent,
+    backgroundColor: Theme.of(context).canvasColor,
     iconTheme: IconThemeData(color: Color(0xFFDC4654)),
   );
 }

--- a/lib/pages/components/issue_intro_card.dart
+++ b/lib/pages/components/issue_intro_card.dart
@@ -1,77 +1,112 @@
+import 'package:bugheist/data/models.dart';
+import 'package:bugheist/routes/routing.dart';
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
 
 class IssueCard extends StatelessWidget {
-  final String description;
-  final String imageSrc;
+  final Results result;
 
-  const IssueCard({
-    Key? key,
-    required this.description,
-    required this.imageSrc,
-  }) : super(key: key);
+  const IssueCard({Key? key, required this.result}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        Card(
-          margin: EdgeInsets.all(10),
-          elevation: 0,
-          clipBehavior: Clip.antiAlias,
-          shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.only(
-                  topRight: Radius.circular(15.0),
-                  bottomRight: Radius.circular(15.0))),
-          child: Container(
-            height: 130,
-            padding: const EdgeInsets.all(0),
-            child: Row(
-              children: <Widget>[
-                Container(
-                  width: 200,
-                  height: 130,
-                  child: Hero(
-                    tag: imageSrc,
-                    child: DecoratedBox(
-                      decoration: BoxDecoration(
-                        image: DecorationImage(
-                          image: NetworkImage(imageSrc),
-                          fit: BoxFit.cover,
-                        ),
-                      ),
+    final Size size = MediaQuery.of(context).size;
+    return Card(
+      margin: EdgeInsets.all(10),
+      elevation: 0,
+      clipBehavior: Clip.antiAlias,
+      color: Color(0xFF737373).withOpacity(0.15),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: InkWell(
+        onTap: () {
+          Navigator.pushNamed(
+            context,
+            RouteManager.issueDetailPage,
+            arguments: result,
+          );
+        },
+        child: Container(
+          height: 0.334 * size.height,
+          child: Column(
+            children: <Widget>[
+              Container(
+                width: size.width,
+                height: 0.2 * size.height,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    image: DecorationImage(
+                      image: NetworkImage(result.screenshot),
+                      fit: BoxFit.cover,
                     ),
                   ),
                 ),
-                Flexible(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 10,
+              ),
+              Container(
+                width: size.width,
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Container(
+                      padding: const EdgeInsets.only(top: 12),
+                      child: Text(
+                        "Issue #" + result.id,
+                        overflow: TextOverflow.ellipsis,
+                        softWrap: true,
+                        style: GoogleFonts.ubuntu(
+                          textStyle: TextStyle(
+                            color: Color(0xFFDC4654),
+                            fontSize: 17.5,
+                          ),
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
                     ),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: <Widget>[
-                        Row(
-                          children: <Widget>[
-                            Flexible(
-                              child: Text(
-                                description,
-                                overflow: TextOverflow.ellipsis,
-                                softWrap: true,
-                                style: TextStyle(
-                                    fontWeight: FontWeight.w600, fontSize: 12),
+                    Container(
+                      padding: const EdgeInsets.only(top: 8, bottom: 12),
+                      child: Text(
+                        result.description.replaceAll("\n", " "),
+                        overflow: TextOverflow.ellipsis,
+                        softWrap: true,
+                        style: GoogleFonts.aBeeZee(
+                          textStyle: TextStyle(
+                            fontSize: 12,
+                            color: Color(0xFF737373),
+                          ),
+                        ),
+                      ),
+                    ),
+                    Row(
+                      children: [
+                        Container(
+                          padding: const EdgeInsets.only(bottom: 12),
+                          child: Text(
+                            result.createdOn.toLocal().day.toString() +
+                                "/" +
+                                result.createdOn.toLocal().month.toString() +
+                                "/" +
+                                result.createdOn.toLocal().year.toString(),
+                            overflow: TextOverflow.ellipsis,
+                            softWrap: true,
+                            style: GoogleFonts.aBeeZee(
+                              textStyle: TextStyle(
+                                fontSize: 10,
+                                color: Color(0xFFA3A3A3),
                               ),
                             ),
-                          ],
+                          ),
                         ),
                       ],
                     ),
-                  ),
-                )
-              ],
-            ),
+                  ],
+                ),
+              )
+            ],
           ),
-        )
-      ],
+        ),
+      ),
     );
   }
 }

--- a/lib/pages/global_leaderboard.dart
+++ b/lib/pages/global_leaderboard.dart
@@ -1,0 +1,217 @@
+import 'package:bugheist/services/api.dart';
+import 'package:flutter/material.dart';
+import 'dart:async';
+
+import 'package:google_fonts/google_fonts.dart';
+
+class GlobalLeaderBoardPage extends StatefulWidget {
+  const GlobalLeaderBoardPage({Key? key}) : super(key: key);
+
+  @override
+  _GlobalLeaderBoardPageState createState() => _GlobalLeaderBoardPageState();
+}
+
+class _GlobalLeaderBoardPageState extends State<GlobalLeaderBoardPage> {
+  int i = 0;
+  Color my = Colors.brown;
+  late Future _getObj;
+
+  @override
+  void initState() {
+    var paginatedUrl = 'https://www.bugheist.com/api/v1/userscore/';
+    _getObj = ApiBackend().getLeaderData(paginatedUrl);
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  CircleAvatar buildAvatar(String partUrl) {
+    try {
+      if (partUrl == "")
+        return CircleAvatar(
+          foregroundColor: Colors.transparent,
+          // backgroundColor: Colors.transparent,
+          radius: 20,
+          child: Icon(
+            Icons.account_circle_outlined,
+            color: Color(0xFFDC4654),
+            size: 40,
+          ),
+        );
+      else
+        return CircleAvatar(
+          foregroundImage:
+              NetworkImage("https://bhfiles.storage.googleapis.com/" + partUrl),
+          radius: 20,
+        );
+    } on Exception {
+      return CircleAvatar(
+        foregroundColor: Colors.transparent,
+        backgroundColor: Colors.transparent,
+        child: Icon(
+          Icons.account_circle_outlined,
+          color: Colors.white,
+          size: 20,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Size size = MediaQuery.of(context).size;
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: Icon(
+            Icons.arrow_back_ios_new_rounded,
+          ),
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+        ),
+        title: Text("Global Leaderboard"),
+        backgroundColor: Color(0xFFDC4654),
+      ),
+      body: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Container(
+              padding: EdgeInsets.symmetric(horizontal: 20),
+              width: size.width,
+              color: Theme.of(context).canvasColor,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    padding: EdgeInsets.fromLTRB(0, 12, 0, 12),
+                    child: Text(
+                      'Global Leaderboards',
+                      style: GoogleFonts.ubuntu(
+                        textStyle: TextStyle(
+                          color: Color(0xFF737373),
+                          fontSize: 25,
+                        ),
+                      ),
+                    ),
+                  ),
+                  Container(
+                    padding: EdgeInsets.fromLTRB(0, 0, 0, 16),
+                    child: Text(
+                      "These are the all time best bug finders on BugHeist.",
+                      style: GoogleFonts.aBeeZee(
+                        textStyle: TextStyle(
+                          color: Color(0xFF737373),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Container(
+              height: size.height * 0.8,
+              padding: EdgeInsets.symmetric(horizontal: 20),
+              child: FutureBuilder(
+                future: _getObj,
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState == ConnectionState.done) {
+                    if (snapshot.hasError) {
+                      return Center(
+                        child: Text(
+                          'Something went wrong!',
+                          style: TextStyle(fontSize: 18),
+                        ),
+                      );
+                    } else if (snapshot.hasData) {
+                      final list = snapshot.data as List;
+                      i = 0;
+                      return Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 0.0,
+                          vertical: 20.0,
+                        ),
+                        child: Material(
+                          color: Colors.transparent,
+                          child: ListView.builder(
+                            itemCount: list.length,
+                            itemBuilder: (context, index) {
+                              int title = list[index].title;
+                              return ListTile(
+                                onTap: () {},
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: index == 0
+                                      ? BorderRadius.only(
+                                          topLeft: Radius.circular(10),
+                                          topRight: Radius.circular(15),
+                                        )
+                                      : index == list.length - 1
+                                          ? BorderRadius.only(
+                                              bottomLeft: Radius.circular(10),
+                                              bottomRight: Radius.circular(10),
+                                            )
+                                          : BorderRadius.only(
+                                              topLeft: Radius.circular(0),
+                                            ),
+                                ),
+                                tileColor: title == 1
+                                    ? Color(0xFFC9AE5D).withOpacity(0.42)
+                                    : title == 2
+                                        ? Color(0xFFADD8E6).withOpacity(0.42)
+                                        : title == 3
+                                            ? Color(0xFFFFD700)
+                                                .withOpacity(0.42)
+                                            : Colors.white,
+                                leading: buildAvatar(list[index].image),
+                                title: Text(
+                                  list[index].user,
+                                  style: GoogleFonts.ubuntu(
+                                    textStyle: TextStyle(
+                                      color: Color(0xFFDC4654),
+                                    ),
+                                  ),
+                                  maxLines: 6,
+                                ),
+                                subtitle: Text(
+                                  list[index].score.toString() + " points",
+                                  style: GoogleFonts.aBeeZee(
+                                    textStyle: TextStyle(
+                                      color: Color(0xFF737373),
+                                      fontSize: 12,
+                                    ),
+                                  ),
+                                ),
+                                trailing: Text(
+                                  "# " + (index + 1).toString(),
+                                  style: GoogleFonts.ubuntu(
+                                    textStyle: TextStyle(
+                                      color: Color(0xFF737373),
+                                      fontSize: 15,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                      );
+                    }
+                  }
+                  return Center(
+                    child: CircularProgressIndicator(),
+                  );
+                },
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -23,9 +23,9 @@ class _HomeState extends State<Home> {
   late PageController _pageController;
 
   final List<Widget> _children = [
-    PaginatedClass(),
-    ReportBug(),
     Feed(),
+    ReportBug(),
+    PaginatedClass(),
     LeaderBoard()
   ];
   void _onItemTapped(int index) {

--- a/lib/pages/issue_detail.dart
+++ b/lib/pages/issue_detail.dart
@@ -1,126 +1,133 @@
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
 import '../data/models.dart';
 
-class ArticleOnePage extends StatelessWidget {
+class IssueDetailPage extends StatelessWidget {
   static final String path = "lib/src/pages/blog/article1.dart";
   final Results issue;
 
-  const ArticleOnePage({
+  const IssueDetailPage({
     Key? key,
     required this.issue,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final Size size = MediaQuery.of(context).size;
+
     return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: Icon(
+            Icons.arrow_back_ios_new_rounded,
+          ),
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+        ),
+        title: Text("Issue #" + issue.id),
+        backgroundColor: Color(0xFFDC4654),
+      ),
       body: SingleChildScrollView(
         child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            Stack(
-              children: <Widget>[
-                SafeArea(
-                  child: Container(
-                    height: 300,
-                    width: double.infinity,
-                    child: Hero(
-                      tag: issue.screenshot,
-                      child: DecoratedBox(
-                        decoration: BoxDecoration(
-                          image: DecorationImage(
-                            image: NetworkImage(
-                              issue.screenshot,
-                            ),
-                            fit: BoxFit.fitWidth,
-                          ),
+            Container(
+              padding: EdgeInsets.symmetric(horizontal: 20),
+              width: size.width,
+              color: Theme.of(context).canvasColor,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    padding: EdgeInsets.fromLTRB(0, 12, 0, 0),
+                    child: Text(
+                      "Issue #" + issue.id,
+                      style: GoogleFonts.ubuntu(
+                        textStyle: TextStyle(
+                          color: Color(0xFF737373),
+                          fontSize: 25,
                         ),
                       ),
                     ),
                   ),
-                ),
-                Positioned(
-                  top: 15,
-                  child: SafeArea(
-                    child: RawMaterialButton(
-                      onPressed: () => Navigator.pop(context),
-                      elevation: 5,
-                      fillColor: Colors.white,
-                      child: Icon(
-                        Icons.arrow_left_rounded,
-                        size: 50,
-                      ),
-                      shape: CircleBorder(),
+                  Container(
+                    // padding: const EdgeInsets.only(bottom: 12),
+                    child: Row(
+                      children: [
+                        Text(
+                          "Created On " +
+                              issue.createdOn.toLocal().day.toString() +
+                              "/" +
+                              issue.createdOn.toLocal().month.toString() +
+                              "/" +
+                              issue.createdOn.toLocal().year.toString(),
+                          overflow: TextOverflow.ellipsis,
+                          softWrap: true,
+                          style: GoogleFonts.aBeeZee(
+                            textStyle: TextStyle(
+                              fontSize: 12,
+                              color: Color(0xFFA3A3A3),
+                            ),
+                          ),
+                        ),
+                        SizedBox(
+                          width: 10,
+                        ),
+                        Chip(
+                          label: Text(
+                            (issue.isOpen) ? "Open" : "Closed",
+                            style: GoogleFonts.aBeeZee(
+                              textStyle: TextStyle(
+                                fontSize: 10,
+                                color: (issue.isOpen)
+                                    ? Color(0xFFA3A3A3)
+                                    : Color(0xFFDC4654),
+                              ),
+                            ),
+                          ),
+                        )
+                      ],
                     ),
                   ),
-                ),
-                // Positioned(
-                //   bottom: 20.0,
-                //   left: 20.0,
-                //   right: 20.0,
-                //   child: Row(
-                //     children: <Widget>[
-                //       Icon(
-                //         Icons.slideshow,
-                //         color: Colors.white,
-                //       ),
-                //       SizedBox(width: 10.0),
-                //       Text(
-                //         "Technology",
-                //         style: TextStyle(color: Colors.white),
-                //       )
-                //     ],
-                //   ),
-                // )
-              ],
-            ),
-            Padding(
-              padding:
-                  const EdgeInsets.only(left: 16.0, right: 16.0, bottom: 16.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  // Row(
-                  //   children: <Widget>[
-                  //     Expanded(
-                  //       child: Text("Oct 21, 2017"),
-                  //     ),
-                  //     IconButton(
-                  //       icon: Icon(Icons.share),
-                  //       onPressed: () {},
-                  //     )
-                  //   ],
-                  // ),
-                  // Text(
-                  //   "testing",
-                  // ),
-                  Divider(),
-                  SizedBox(
-                    height: 10.0,
-                  ),
-                  // Row(
-                  //   children: <Widget>[
-                  //     Icon(Icons.favorite_border),
-                  //     SizedBox(
-                  //       width: 5.0,
-                  //     ),
-                  //     Text("20.2k"),
-                  //     SizedBox(
-                  //       width: 16.0,
-                  //     ),
-                  //     Icon(Icons.comment),
-                  //     SizedBox(
-                  //       width: 5.0,
-                  //     ),
-                  //     Text("2.2k"),
-                  //   ],
-                  // ),
-                  // SizedBox(
-                  //   height: 10.0,
-                  // ),
-                  Text(
-                    issue.description,
-                    textAlign: TextAlign.justify,
-                  )
                 ],
+              ),
+            ),
+            Container(
+              height: 0.334 * size.height,
+              width: size.width,
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(10),
+                  image: DecorationImage(
+                    image: NetworkImage(
+                      issue.screenshot,
+                    ),
+                    fit: BoxFit.fill,
+                  ),
+                ),
+              ),
+            ),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+              child: Text(
+                "Description",
+                overflow: TextOverflow.ellipsis,
+                softWrap: true,
+                style: GoogleFonts.ubuntu(
+                  textStyle: TextStyle(
+                    color: Color(0xFFDC4654),
+                    fontSize: 17.5,
+                  ),
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: Text(
+                issue.description,
               ),
             ),
           ],

--- a/lib/pages/issues.dart
+++ b/lib/pages/issues.dart
@@ -1,6 +1,7 @@
+import 'package:google_fonts/google_fonts.dart';
+
 import './components/issue_intro_card.dart';
 import 'package:flutter/material.dart';
-import '../pages/issue_detail.dart';
 
 import '../services/api.dart';
 import '../data/models.dart';
@@ -77,74 +78,104 @@ class PaginatedClassState extends State<PaginatedClass>
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
-      child: Scaffold(
-        body: FutureBuilder(
-          future: _getObj,
-          builder: (context, snapshot) {
-            if (snapshot.connectionState == ConnectionState.done) {
-              if (snapshot.hasError) {
-                return Center(
-                  child: Text(
-                    'Something went wrong!',
-                    style: TextStyle(fontSize: 18),
+    final Size size = MediaQuery.of(context).size;
+
+    return Scaffold(
+      body: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              padding: EdgeInsets.symmetric(horizontal: 20),
+              width: size.width,
+              color: Theme.of(context).canvasColor,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    padding: EdgeInsets.fromLTRB(0, 12, 0, 12),
+                    child: Text(
+                      'Issues',
+                      style: GoogleFonts.ubuntu(
+                        textStyle: TextStyle(
+                          color: Color(0xFF737373),
+                          fontSize: 25,
+                        ),
+                      ),
+                    ),
                   ),
-                );
-              } else if (snapshot.hasData) {
-                return ListView.builder(
-                    itemCount: (snapshot.data! as DataModel).results.length + 1,
-                    controller: _scrollController,
-                    itemBuilder: (context, index) {
-                      if (index == (snapshot.data! as DataModel).results.length)
-                        return Center(
-                          child: Opacity(
-                            opacity: _loading ? 1.0 : 0.0,
-                            child: CircularProgressIndicator(
-                              valueColor: animationController.drive(
-                                ColorTween(
-                                  begin: Colors.blueAccent,
-                                  end: Colors.red,
-                                ),
-                              ),
-                            ),
-                          ),
-                        );
-                      else
-                        return new GestureDetector(
-                          onTap: () => {
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (context) => ArticleOnePage(
-                                  issue: (snapshot.data! as DataModel)
-                                      .results[index],
-                                ),
-                              ),
-                            )
-                          },
-                          child: IssueCard(
-                            description: (snapshot.data! as DataModel)
-                                .results[index]
-                                .description,
-                            imageSrc: (snapshot.data! as DataModel)
-                                .results[index]
-                                .screenshot,
-                          ),
-                        );
-                    });
-              }
-            }
-            return Center(
-              child: CircularProgressIndicator(
-                valueColor: animationController.drive(
-                  ColorTween(
-                    begin: Colors.blueAccent,
-                    end: Colors.red,
+                  Container(
+                    padding: EdgeInsets.fromLTRB(0, 0, 0, 16),
+                    child: Text(
+                      "Check out the latest issues found and reported, maybe find a fix too?",
+                      style: GoogleFonts.aBeeZee(
+                        textStyle: TextStyle(
+                          color: Color(0xFF737373),
+                        ),
+                      ),
+                    ),
                   ),
-                ),
+                ],
               ),
-            );
-          },
+            ),
+            Container(
+              height: size.height * 0.8,
+              padding: EdgeInsets.symmetric(horizontal: 20),
+              child: FutureBuilder(
+                future: _getObj,
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState == ConnectionState.done) {
+                    if (snapshot.hasError) {
+                      return Center(
+                        child: Text(
+                          'Something went wrong!',
+                          style: TextStyle(fontSize: 18),
+                        ),
+                      );
+                    } else if (snapshot.hasData) {
+                      return ListView.builder(
+                        itemCount:
+                            (snapshot.data! as DataModel).results.length + 1,
+                        controller: _scrollController,
+                        itemBuilder: (context, index) {
+                          if (index ==
+                              (snapshot.data! as DataModel).results.length)
+                            return Center(
+                              child: Opacity(
+                                opacity: _loading ? 1.0 : 0.0,
+                                child: CircularProgressIndicator(
+                                  valueColor: animationController.drive(
+                                    ColorTween(
+                                      begin: Colors.blueAccent,
+                                      end: Colors.red,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            );
+                          else
+                            return IssueCard(
+                              result:
+                                  (snapshot.data! as DataModel).results[index],
+                            );
+                        },
+                      );
+                    }
+                  }
+                  return Center(
+                    child: CircularProgressIndicator(
+                      valueColor: animationController.drive(
+                        ColorTween(
+                          begin: Colors.blueAccent,
+                          end: Colors.red,
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/pages/leaderboard.dart
+++ b/lib/pages/leaderboard.dart
@@ -2,6 +2,10 @@ import 'package:bugheist/services/api.dart';
 import 'package:flutter/material.dart';
 import 'dart:async';
 
+import 'package:google_fonts/google_fonts.dart';
+
+import '../routes/routing.dart';
+
 class LeaderBoard extends StatefulWidget {
   const LeaderBoard({Key? key}) : super(key: key);
 
@@ -13,11 +17,15 @@ class _LeaderBoardState extends State<LeaderBoard> {
   int i = 0;
   Color my = Colors.brown;
   late Future _getObj;
+  late Future _getCompany;
 
   @override
   void initState() {
     var paginatedUrl = 'https://www.bugheist.com/api/v1/userscore/';
     _getObj = ApiBackend().getLeaderData(paginatedUrl);
+    var companyPaginatedUrl = 'https://www.bugheist.com/api/v1/scoreboard/';
+    _getCompany = ApiBackend().getScoreBoardData(companyPaginatedUrl);
+
     super.initState();
   }
 
@@ -58,41 +66,113 @@ class _LeaderBoardState extends State<LeaderBoard> {
     }
   }
 
+  CircleAvatar buildLogo(String partUrl) {
+    try {
+      if (partUrl == "")
+        return CircleAvatar(
+          foregroundColor: Colors.transparent,
+          // backgroundColor: Colors.transparent,
+          radius: 20,
+          child: Icon(
+            Icons.account_circle_outlined,
+            color: Color(0xFFDC4654),
+            size: 40,
+          ),
+        );
+      else
+        return CircleAvatar(
+          foregroundImage: NetworkImage(
+            "https://storage.googleapis.com/bhfiles/" + partUrl,
+          ),
+          radius: 20,
+        );
+    } on Exception {
+      return CircleAvatar(
+        foregroundColor: Colors.transparent,
+        backgroundColor: Colors.transparent,
+        child: Icon(
+          Icons.account_circle_outlined,
+          color: Colors.white,
+          size: 20,
+        ),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    var r = TextStyle(fontSize: 34);
-    return Stack(
-      children: <Widget>[
-        Scaffold(
-          body: Container(
-            margin: EdgeInsets.only(top: 10.0),
+    final Size size = MediaQuery.of(context).size;
+
+    return SingleChildScrollView(
+      padding: EdgeInsets.symmetric(horizontal: 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            padding: EdgeInsets.fromLTRB(0, 12, 0, 12),
+            alignment: Alignment.centerLeft,
+            child: Text(
+              "Leaderboards",
+              style: GoogleFonts.ubuntu(
+                textStyle: TextStyle(color: Color(0xFF737373), fontSize: 30),
+              ),
+            ),
+          ),
+          Container(
+            padding: EdgeInsets.fromLTRB(0, 0, 0, 16),
+            child: Text(
+              "Find out the users best at heisting those bugs and companies that are the most active!",
+              style: GoogleFonts.aBeeZee(
+                textStyle: TextStyle(
+                  color: Color(0xFF737373),
+                ),
+              ),
+            ),
+          ),
+          Container(
+            padding: EdgeInsets.fromLTRB(0, 0, 0, 12),
             child: Column(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: <Widget>[
-                Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 8),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Padding(
-                        padding: const EdgeInsets.all(8.0),
-                        child: Icon(
-                          Icons.public,
-                          color: Color(0xFFDC4654),
-                        ),
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                ListTile(
+                  // leading: Icon(
+                  //   Icons.public,
+                  //   color: Color(0xFFDC4654),
+                  // ),
+                  title: Text(
+                    "Global Leaderboard",
+                    style: GoogleFonts.ubuntu(
+                      textStyle: TextStyle(
+                        color: Color(0xFFDC4654),
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
                       ),
-                      Text(
-                        'Global Leaderboard ',
-                        style: TextStyle(
-                          fontWeight: FontWeight.bold,
-                          fontSize: 25,
-                          color: Color(0xFFDC4654),
-                        ),
-                      ),
-                    ],
+                    ),
+                  ),
+                  trailing: IconButton(
+                    icon: Icon(
+                      Icons.arrow_forward_ios_rounded,
+                      color: Color(0xFFDC4654),
+                    ),
+                    onPressed: () {
+                      Navigator.pushNamed(
+                        context,
+                        RouteManager.globalLeaderboardPage,
+                      );
+                    },
                   ),
                 ),
-                Flexible(
+                Text(
+                  "Find out the best of the best, the all time finest bug finders!",
+                  style: GoogleFonts.aBeeZee(
+                    textStyle: TextStyle(
+                      color: Color(0xFF737373),
+                    ),
+                  ),
+                ),
+                Container(
+                  height: 0.3 * size.height,
+                  padding: const EdgeInsets.fromLTRB(0, 20, 0, 10),
                   child: FutureBuilder(
                     future: _getObj,
                     builder: (context, snapshot) {
@@ -107,71 +187,71 @@ class _LeaderBoardState extends State<LeaderBoard> {
                         } else if (snapshot.hasData) {
                           final list = snapshot.data as List;
                           i = 0;
-                          return Padding(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 0.0,
-                              vertical: 10.0,
-                            ),
+                          return InkWell(
+                            onTap: () {
+                              Navigator.pushNamed(
+                                context,
+                                RouteManager.globalLeaderboardPage,
+                              );
+                            },
                             child: ListView.builder(
-                              itemCount: list.length,
+                              padding: EdgeInsets.zero,
+                              itemCount: 3,
+                              shrinkWrap: true,
                               itemBuilder: (context, index) {
-                                int title = list[index].title;
-                                return Padding(
-                                  padding: const EdgeInsets.symmetric(
-                                      horizontal: 10.0, vertical: 0.0),
-                                  child: ListTile(
-                                    onTap: () {},
-                                    shape: RoundedRectangleBorder(
-                                      borderRadius: index == 0
-                                          ? BorderRadius.only(
-                                              topLeft: Radius.circular(10),
-                                              topRight: Radius.circular(15),
-                                            )
-                                          : index == list.length - 1
-                                              ? BorderRadius.only(
-                                                  bottomLeft:
-                                                      Radius.circular(10),
-                                                  bottomRight:
-                                                      Radius.circular(10),
-                                                )
-                                              : BorderRadius.only(
-                                                  topLeft: Radius.circular(0),
-                                                ),
-                                    ),
-                                    tileColor: title == 1
-                                        ? Colors.brown.withOpacity(0.2)
-                                        : title == 2
-                                            ? Colors.grey.withOpacity(0.2)
-                                            : title == 3
-                                                ? Colors.yellow.withOpacity(0.2)
-                                                : Colors.white,
-                                    leading: buildAvatar(list[index].image),
-                                    title: Text(
-                                      list[index].user,
-                                      style: TextStyle(
-                                          color: Colors.deepPurple,
-                                          fontWeight: FontWeight.w500),
-                                      maxLines: 6,
-                                    ),
-                                    subtitle: Text(
-                                      "Points: " + list[index].score.toString(),
-                                    ),
-                                    trailing: title == 3
-                                        ? Text(
-                                            "🥇",
-                                            style: r,
+                                return ListTile(
+                                  shape: RoundedRectangleBorder(
+                                    borderRadius: index == 0
+                                        ? BorderRadius.only(
+                                            topLeft: Radius.circular(10),
+                                            topRight: Radius.circular(15),
                                           )
-                                        : title == 2
-                                            ? Text(
-                                                "🥈",
-                                                style: r,
+                                        : index == 2
+                                            ? BorderRadius.only(
+                                                bottomLeft: Radius.circular(10),
+                                                bottomRight:
+                                                    Radius.circular(10),
                                               )
-                                            : title == 1
-                                                ? Text(
-                                                    "🥉",
-                                                    style: r,
-                                                  )
-                                                : Text(''),
+                                            : BorderRadius.only(
+                                                topLeft: Radius.circular(0),
+                                              ),
+                                  ),
+                                  tileColor: index == 2
+                                      ? Color(0xFFC9AE5D).withOpacity(0.42)
+                                      : index == 1
+                                          ? Color(0xFFADD8E6).withOpacity(0.42)
+                                          : index == 0
+                                              ? Color(0xFFFFD700)
+                                                  .withOpacity(0.42)
+                                              : Colors.white,
+                                  leading: buildAvatar(list[index].image),
+                                  title: Text(
+                                    list[index].user,
+                                    style: GoogleFonts.ubuntu(
+                                      textStyle: TextStyle(
+                                        color: Color(0xFFDC4654),
+                                      ),
+                                    ),
+                                    maxLines: 6,
+                                  ),
+                                  subtitle: Text(
+                                    list[index].score.toString() + " points",
+                                    style: GoogleFonts.aBeeZee(
+                                      textStyle: TextStyle(
+                                        color: Color(0xFF737373),
+                                        fontSize: 12,
+                                      ),
+                                    ),
+                                  ),
+                                  trailing: Text(
+                                    "# " + (index + 1).toString(),
+                                    style: GoogleFonts.ubuntu(
+                                      textStyle: TextStyle(
+                                        color: Color(0xFF737373),
+                                        fontSize: 15,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
                                   ),
                                 );
                               },
@@ -184,12 +264,279 @@ class _LeaderBoardState extends State<LeaderBoard> {
                       );
                     },
                   ),
-                )
+                ),
               ],
             ),
           ),
-        ),
-      ],
+          Container(
+            padding: EdgeInsets.fromLTRB(0, 0, 0, 12),
+            color: Theme.of(context).canvasColor,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                ListTile(
+                  title: Text(
+                    "Monthly Leaderboard",
+                    style: GoogleFonts.ubuntu(
+                      textStyle: TextStyle(
+                        color: Color(0xFFDC4654),
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  trailing: IconButton(
+                    icon: Icon(
+                      Icons.arrow_forward_ios_rounded,
+                      color: Color(0xFFDC4654),
+                    ),
+                    onPressed: () {
+                      Navigator.pushNamed(
+                        context,
+                        RouteManager.monthlyLeaderboardPage,
+                      );
+                    },
+                  ),
+                ),
+                Text(
+                  "Check the best bug hunters of this month.!",
+                  style: GoogleFonts.aBeeZee(
+                    textStyle: TextStyle(
+                      color: Color(0xFF737373),
+                    ),
+                  ),
+                ),
+                Container(
+                  height: 0.3 * size.height,
+                  padding: const EdgeInsets.fromLTRB(0, 20, 0, 10),
+                  child: FutureBuilder(
+                    future: _getObj,
+                    builder: (context, snapshot) {
+                      if (snapshot.connectionState == ConnectionState.done) {
+                        if (snapshot.hasError) {
+                          return Center(
+                            child: Text(
+                              'Something went wrong!',
+                              style: TextStyle(fontSize: 18),
+                            ),
+                          );
+                        } else if (snapshot.hasData) {
+                          final list = snapshot.data as List;
+                          i = 0;
+                          return InkWell(
+                            onTap: () {
+                              Navigator.pushNamed(
+                                context,
+                                RouteManager.monthlyLeaderboardPage,
+                              );
+                            },
+                            child: Material(
+                              color: Colors.transparent,
+                              child: ListView.builder(
+                                padding: EdgeInsets.zero,
+                                itemCount: 3,
+                                shrinkWrap: true,
+                                itemBuilder: (context, index) {
+                                  return ListTile(
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: index == 0
+                                          ? BorderRadius.only(
+                                              topLeft: Radius.circular(10),
+                                              topRight: Radius.circular(15),
+                                            )
+                                          : index == 2
+                                              ? BorderRadius.only(
+                                                  bottomLeft:
+                                                      Radius.circular(10),
+                                                  bottomRight:
+                                                      Radius.circular(10),
+                                                )
+                                              : BorderRadius.only(
+                                                  topLeft: Radius.circular(0),
+                                                ),
+                                    ),
+                                    tileColor:
+                                        Color(0xFFECECEC).withOpacity(0.42),
+                                    leading: buildAvatar(list[index].image),
+                                    title: Text(
+                                      list[index].user,
+                                      style: GoogleFonts.ubuntu(
+                                        textStyle: TextStyle(
+                                          color: Color(0xFFDC4654),
+                                        ),
+                                      ),
+                                      maxLines: 6,
+                                    ),
+                                    subtitle: Text(
+                                      list[index].score.toString() + " points",
+                                      style: GoogleFonts.aBeeZee(
+                                        textStyle: TextStyle(
+                                          color: Color(0xFF737373),
+                                          fontSize: 12,
+                                        ),
+                                      ),
+                                    ),
+                                    trailing: Text(
+                                      "# " + (index + 1).toString(),
+                                      style: GoogleFonts.ubuntu(
+                                        textStyle: TextStyle(
+                                          color: Color(0xFF737373),
+                                          fontSize: 15,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                      ),
+                                    ),
+                                  );
+                                },
+                              ),
+                            ),
+                          );
+                        }
+                      }
+                      return Center(
+                        child: CircularProgressIndicator(),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Container(
+            padding: EdgeInsets.fromLTRB(0, 0, 0, 12),
+            color: Theme.of(context).canvasColor,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                ListTile(
+                  title: Text(
+                    "Company Scoreboard",
+                    style: GoogleFonts.ubuntu(
+                      textStyle: TextStyle(
+                        color: Color(0xFFDC4654),
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  trailing: IconButton(
+                    icon: Icon(
+                      Icons.arrow_forward_ios_rounded,
+                      color: Color(0xFFDC4654),
+                    ),
+                    onPressed: () {
+                      Navigator.pushNamed(
+                        context,
+                        RouteManager.companyScoreboardPage,
+                      );
+                    },
+                  ),
+                ),
+                Text(
+                  "Take a look at the most active companies on BugHeist!",
+                  style: GoogleFonts.aBeeZee(
+                    textStyle: TextStyle(
+                      color: Color(0xFF737373),
+                    ),
+                  ),
+                ),
+                Container(
+                  height: 0.3 * size.height,
+                  padding: const EdgeInsets.fromLTRB(0, 20, 0, 10),
+                  child: FutureBuilder(
+                    future: _getCompany,
+                    builder: (context, snapshot) {
+                      if (snapshot.connectionState == ConnectionState.done) {
+                        if (snapshot.hasError) {
+                          return Center(
+                            child: Text(
+                              'Something went wrong!',
+                              style: TextStyle(fontSize: 18),
+                            ),
+                          );
+                        } else if (snapshot.hasData) {
+                          final list = snapshot.data as List;
+                          return InkWell(
+                            onTap: () {
+                              Navigator.pushNamed(
+                                context,
+                                RouteManager.companyScoreboardPage,
+                              );
+                            },
+                            child: Material(
+                              color: Colors.transparent,
+                              child: ListView.builder(
+                                itemCount: 3,
+                                itemBuilder: (context, index) {
+                                  return ListTile(
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: index == 0
+                                          ? BorderRadius.only(
+                                              topLeft: Radius.circular(10),
+                                              topRight: Radius.circular(15),
+                                            )
+                                          : index == 2
+                                              ? BorderRadius.only(
+                                                  bottomLeft:
+                                                      Radius.circular(10),
+                                                  bottomRight:
+                                                      Radius.circular(10),
+                                                )
+                                              : BorderRadius.only(
+                                                  topLeft: Radius.circular(0),
+                                                ),
+                                    ),
+                                    tileColor: Color(0xFFE0E0E0),
+                                    leading: buildLogo(list[index].logoLink),
+                                    title: Text(
+                                      list[index].companyName,
+                                      style: GoogleFonts.ubuntu(
+                                        textStyle: TextStyle(
+                                          color: Color(0xFFDC4654),
+                                        ),
+                                      ),
+                                      maxLines: 6,
+                                    ),
+                                    subtitle: Text(
+                                      "Open: " +
+                                          list[index].openIssues.toString() +
+                                          "| Closed: " +
+                                          list[index].closedIssues.toString(),
+                                      style: GoogleFonts.aBeeZee(
+                                        textStyle: TextStyle(
+                                          color: Color(0xFF737373),
+                                          fontSize: 12,
+                                        ),
+                                      ),
+                                    ),
+                                    trailing: Text(
+                                      list[index].topTester.toString(),
+                                      style: GoogleFonts.ubuntu(
+                                        textStyle: TextStyle(
+                                          color: Color(0xFF737373),
+                                          fontSize: 15,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                      ),
+                                    ),
+                                  );
+                                },
+                              ),
+                            ),
+                          );
+                        }
+                      }
+                      return Center(
+                        child: CircularProgressIndicator(),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/pages/legal.dart
+++ b/lib/pages/legal.dart
@@ -1,4 +1,3 @@
-import 'package:bugheist/constants/legal_constants.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -68,6 +67,7 @@ class LegalPage extends StatelessWidget {
                       (BuildContext context, AsyncSnapshot<String> snapshot) {
                     if (snapshot.hasData) {
                       return Markdown(
+                        physics: const NeverScrollableScrollPhysics(),
                         data: snapshot.data!,
                         padding: EdgeInsets.all(0),
                         styleSheet: MarkdownStyleSheet.fromTheme(
@@ -104,15 +104,35 @@ class LegalPage extends StatelessWidget {
               ),
             ),
             Container(
+              height: 800,
               padding: EdgeInsets.fromLTRB(0, 0, 0, 36),
-              child: Text(
-                privacyPolicy,
-                style: GoogleFonts.aBeeZee(
-                  textStyle: TextStyle(
-                    color: Color(0xFF737373),
-                  ),
-                ),
-              ),
+              child: FutureBuilder(
+                  future: rootBundle.loadString("assets/privacy_policy.md"),
+                  builder:
+                      (BuildContext context, AsyncSnapshot<String> snapshot) {
+                    if (snapshot.hasData) {
+                      return Markdown(
+                        data: snapshot.data!,
+                        padding: EdgeInsets.all(0),
+                        styleSheet: MarkdownStyleSheet.fromTheme(
+                          ThemeData(
+                            textTheme: TextTheme(
+                              bodyText2: GoogleFonts.aBeeZee(
+                                textStyle: TextStyle(
+                                  fontSize: 12,
+                                  color: Color(0xFF737373),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      );
+                    }
+
+                    return Center(
+                      child: CircularProgressIndicator(),
+                    );
+                  }),
             ),
           ],
         ),

--- a/lib/pages/monthly_leaderboard.dart
+++ b/lib/pages/monthly_leaderboard.dart
@@ -1,0 +1,199 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../services/api.dart';
+
+class MonthlyLeaderBoardPage extends StatefulWidget {
+  const MonthlyLeaderBoardPage({Key? key}) : super(key: key);
+
+  @override
+  State<MonthlyLeaderBoardPage> createState() => _MonthlyLeaderBoardPageState();
+}
+
+class _MonthlyLeaderBoardPageState extends State<MonthlyLeaderBoardPage> {
+  late Future _getObj;
+
+  CircleAvatar buildAvatar(String partUrl) {
+    try {
+      if (partUrl == "")
+        return CircleAvatar(
+          foregroundColor: Colors.transparent,
+          // backgroundColor: Colors.transparent,
+          radius: 20,
+          child: Icon(
+            Icons.account_circle_outlined,
+            color: Color(0xFFDC4654),
+            size: 40,
+          ),
+        );
+      else
+        return CircleAvatar(
+          foregroundImage:
+              NetworkImage("https://bhfiles.storage.googleapis.com/" + partUrl),
+          radius: 20,
+        );
+    } on Exception {
+      return CircleAvatar(
+        foregroundColor: Colors.transparent,
+        backgroundColor: Colors.transparent,
+        child: Icon(
+          Icons.account_circle_outlined,
+          color: Colors.white,
+          size: 20,
+        ),
+      );
+    }
+  }
+
+  @override
+  void initState() {
+    var paginatedUrl = 'https://www.bugheist.com/api/v1/userscore/';
+    _getObj = ApiBackend().getLeaderData(paginatedUrl);
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Size size = MediaQuery.of(context).size;
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: Icon(
+            Icons.arrow_back_ios_new_rounded,
+          ),
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+        ),
+        title: Text("Monthly Leaderboard"),
+        backgroundColor: Color(0xFFDC4654),
+      ),
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            Container(
+              padding: EdgeInsets.symmetric(horizontal: 20),
+              width: size.width,
+              color: Theme.of(context).canvasColor,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    padding: EdgeInsets.fromLTRB(0, 12, 0, 12),
+                    child: Text(
+                      'Monthly Leaderboards',
+                      style: GoogleFonts.ubuntu(
+                        textStyle: TextStyle(
+                          color: Color(0xFF737373),
+                          fontSize: 25,
+                        ),
+                      ),
+                    ),
+                  ),
+                  Container(
+                    padding: EdgeInsets.fromLTRB(0, 0, 0, 16),
+                    child: Text(
+                      "These are the most active users on BugHeist this month.",
+                      style: GoogleFonts.aBeeZee(
+                        textStyle: TextStyle(
+                          color: Color(0xFF737373),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Container(
+              height: size.height * 0.8,
+              padding: EdgeInsets.symmetric(horizontal: 20),
+              child: FutureBuilder(
+                future: _getObj,
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState == ConnectionState.done) {
+                    if (snapshot.hasError) {
+                      return Center(
+                        child: Text(
+                          'Something went wrong!',
+                          style: TextStyle(fontSize: 18),
+                        ),
+                      );
+                    } else if (snapshot.hasData) {
+                      final list = snapshot.data as List;
+                      return Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 0.0,
+                          vertical: 20.0,
+                        ),
+                        child: Material(
+                          color: Colors.transparent,
+                          child: ListView.builder(
+                            itemCount: list.length,
+                            itemBuilder: (context, index) {
+                              return ListTile(
+                                onTap: () {},
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: index == 0
+                                      ? BorderRadius.only(
+                                          topLeft: Radius.circular(10),
+                                          topRight: Radius.circular(15),
+                                        )
+                                      : index == list.length - 1
+                                          ? BorderRadius.only(
+                                              bottomLeft: Radius.circular(10),
+                                              bottomRight: Radius.circular(10),
+                                            )
+                                          : BorderRadius.only(
+                                              topLeft: Radius.circular(0),
+                                            ),
+                                ),
+                                tileColor: Color(0xFFECECEC).withOpacity(0.42),
+                                leading: buildAvatar(list[index].image),
+                                title: Text(
+                                  list[index].user,
+                                  style: GoogleFonts.ubuntu(
+                                    textStyle: TextStyle(
+                                      color: Color(0xFFDC4654),
+                                    ),
+                                  ),
+                                  maxLines: 6,
+                                ),
+                                subtitle: Text(
+                                  list[index].score.toString() + " points",
+                                  style: GoogleFonts.aBeeZee(
+                                    textStyle: TextStyle(
+                                      color: Color(0xFF737373),
+                                      fontSize: 12,
+                                    ),
+                                  ),
+                                ),
+                                trailing: Text(
+                                  "# " + (index + 1).toString(),
+                                  style: GoogleFonts.ubuntu(
+                                    textStyle: TextStyle(
+                                      color: Color(0xFF737373),
+                                      fontSize: 15,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                      );
+                    }
+                  }
+                  return Center(
+                    child: CircularProgressIndicator(),
+                  );
+                },
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/routing.dart
+++ b/lib/routes/routing.dart
@@ -1,4 +1,5 @@
 // import 'package:bugheist/pages/login.dart';
+import 'package:bugheist/data/models.dart';
 import 'package:bugheist/pages/error.dart';
 import 'package:bugheist/pages/home.dart';
 import 'package:bugheist/pages/legal.dart';
@@ -8,6 +9,10 @@ import 'package:bugheist/pages/profile.dart';
 import 'package:flutter/material.dart';
 
 import '../pages/about.dart';
+import '../pages/company_scoreboard.dart';
+import '../pages/global_leaderboard.dart';
+import '../pages/issue_detail.dart';
+import '../pages/monthly_leaderboard.dart';
 
 class RouteManager {
   static const String profilePage = "/profile";
@@ -18,6 +23,10 @@ class RouteManager {
   static String currentRoute = "/loginSignup";
   static const String legalPage = "/legal";
   static const String aboutPage = "/about";
+  static const String globalLeaderboardPage = "/globalBoard";
+  static const String monthlyLeaderboardPage = "/monthlyBoard";
+  static const String companyScoreboardPage = "/companyBoard";
+  static const String issueDetailPage = "/issueDetail";
 
   static Route<dynamic> generateRoute(RouteSettings settings) {
     final arguments = settings.arguments;
@@ -104,6 +113,85 @@ class RouteManager {
         return PageRouteBuilder(
           pageBuilder: (context, animation, secondaryAnimation) =>
               const AboutPage(),
+          transitionsBuilder: (context, animation, secondaryAnimation, child) {
+            const begin = Offset(1.0, 0);
+            const end = Offset.zero;
+            const curve = Curves.ease;
+
+            var tween =
+                Tween(begin: begin, end: end).chain(CurveTween(curve: curve));
+
+            return SlideTransition(
+              position: animation.drive(tween),
+              child: child,
+            );
+          },
+          transitionDuration: const Duration(milliseconds: 500),
+        );
+      case issueDetailPage:
+        return PageRouteBuilder(
+          pageBuilder: (context, animation, secondaryAnimation) =>
+              IssueDetailPage(
+            issue: arguments as Results,
+          ),
+          transitionsBuilder: (context, animation, secondaryAnimation, child) {
+            const begin = Offset(0.0, 1.0);
+            const end = Offset.zero;
+            const curve = Curves.ease;
+
+            var tween =
+                Tween(begin: begin, end: end).chain(CurveTween(curve: curve));
+
+            return SlideTransition(
+              position: animation.drive(tween),
+              child: child,
+            );
+          },
+          transitionDuration: const Duration(milliseconds: 750),
+        );
+
+      case globalLeaderboardPage:
+        return PageRouteBuilder(
+          pageBuilder: (context, animation, secondaryAnimation) =>
+              const GlobalLeaderBoardPage(),
+          transitionsBuilder: (context, animation, secondaryAnimation, child) {
+            const begin = Offset(1.0, 0);
+            const end = Offset.zero;
+            const curve = Curves.ease;
+
+            var tween =
+                Tween(begin: begin, end: end).chain(CurveTween(curve: curve));
+
+            return SlideTransition(
+              position: animation.drive(tween),
+              child: child,
+            );
+          },
+          transitionDuration: const Duration(milliseconds: 750),
+        );
+      case monthlyLeaderboardPage:
+        return PageRouteBuilder(
+          pageBuilder: (context, animation, secondaryAnimation) =>
+              const MonthlyLeaderBoardPage(),
+          transitionsBuilder: (context, animation, secondaryAnimation, child) {
+            const begin = Offset(1.0, 0);
+            const end = Offset.zero;
+            const curve = Curves.ease;
+
+            var tween =
+                Tween(begin: begin, end: end).chain(CurveTween(curve: curve));
+
+            return SlideTransition(
+              position: animation.drive(tween),
+              child: child,
+            );
+          },
+          transitionDuration: const Duration(milliseconds: 750),
+        );
+      case companyScoreboardPage:
+        return PageRouteBuilder(
+          pageBuilder: (context, animation, secondaryAnimation) =>
+              const CompanyScoreBoardPage(),
           transitionsBuilder: (context, animation, secondaryAnimation, child) {
             const begin = Offset(1.0, 0);
             const end = Offset.zero;

--- a/lib/services/api.dart
+++ b/lib/services/api.dart
@@ -1,3 +1,4 @@
+import 'package:bugheist/models/company_model.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
 import '../data/models.dart';
@@ -26,6 +27,20 @@ class ApiBackend {
               .map((data) => Leaders.fromJson(data))
               .toList();
       return leaders;
+    });
+  }
+
+  Future<List> getScoreBoardData(String paginatedUrl) async {
+    return http
+        .get(
+      Uri.parse(paginatedUrl),
+    )
+        .then((http.Response response) {
+      List<Company> companies =
+          (json.decode(utf8.decode(response.bodyBytes)) as List)
+              .map((data) => Company.fromJson(data))
+              .toList();
+      return companies;
     });
   }
 }


### PR DESCRIPTION
This PR changes the following:
- #16 : Revamped the leader board screen, now this screen features the following: 
   - Global leader board: Re designed the screen.
   - **New Feature:** A monthly leader board, to see the top users of the current month.
   - A company scoreboard: See the next point.
- #42 : Company scoreboard has been incorporated within **leader board screen**.
- #44 : Re-designed the whole issue screen, shifted it to the **issue tab** (previously was in home tab).
- Completed to-do from #94 : Added Privacy Policy found from BLT's API.

TODO: Monthly leader board has no API currently, incorporate datafields when we have one.

_**Note:** Company Scoreboard's API isn't sending latest data, kindly make it so that it sends the latest data which is on the website._

As always, you can track the new UI added/proposed and a prototype for it on Figma [here.](https://www.figma.com/file/NYD5WZzJywnO338lchnece/BugHeist?node-id=7%3A634)

