### PR TITLE
Fix an issue with header

### DIFF
--- a/lib/src/util/api/user_api.dart
+++ b/lib/src/util/api/user_api.dart
@@ -29,7 +29,12 @@ class UserApiClient {
     http.Response? response;
     try {
       String searchUrl = UserEndPoints.userInfo + "?search=${user.username}";
-      response = await http.get(Uri.parse(searchUrl));
+      response = await http.get(
+        Uri.parse(searchUrl),
+        headers: {
+          "Authorization": "Token ${user.token}",
+        },
+      );
       var decodedResponse =
           jsonDecode(utf8.decode(response.bodyBytes))["results"][0];
       user.id = decodedResponse["user"]["id"];


### PR DESCRIPTION
Closes #159 

I have pinpointed the cause of the error. Seems like `api/v1/profile/{USERNAME}` now requires an authorization header, which was not the case before. Fixing that fixes the issue.