### PR TITLE
Search Bar closes on double tapping clear

### DIFF
--- a/lib/src/components/searchbar.dart
+++ b/lib/src/components/searchbar.dart
@@ -12,7 +12,7 @@ class BugHeistSearchDelegate extends SearchDelegate {
     return [
       IconButton(
         onPressed: () {
-          query = '';
+          query != '' ? (query = '') : Navigator.of(context).pop();
         },
         icon: Icon(
           Icons.clear,


### PR DESCRIPTION
fix #181 

Search should close when user double taps on clear icon  .