### PR TITLE
Paste Image Functionality in iOS

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,5 +1,5 @@
-import UIKit
 import Flutter
+import UIKit
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
@@ -7,7 +7,36 @@ import Flutter
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    // Register the method channel
+    let controller = window?.rootViewController as! FlutterViewController
+    let clipboardImageChannel = FlutterMethodChannel(name: "clipboard_image_channel",
+                                                      binaryMessenger: controller.binaryMessenger)
+
+    clipboardImageChannel.setMethodCallHandler { (call: FlutterMethodCall, result: @escaping FlutterResult) in
+      if call.method == "getClipboardImage" {
+        self.getClipboardImage(result: result)
+      } else {
+        result(FlutterMethodNotImplemented)
+      }
+    }
+
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  private func getClipboardImage(result: FlutterResult) {
+    // Check if the clipboard contains an image
+    if let image = UIPasteboard.general.image {
+      // Convert the image to PNG data
+      if let imageData = image.pngData() {
+        // Encode the image data to a Base64 string
+        let base64String = imageData.base64EncodedString()
+        result(base64String) // Send the Base64 string back to Flutter
+      } else {
+        result(FlutterError(code: "NO_IMAGE", message: "Could not convert image to data", details: nil))
+      }
+    } else {
+      result(FlutterError(code: "NO_IMAGE", message: "Clipboard does not contain an image", details: nil))
+    }
   }
 }


### PR DESCRIPTION
## Overview
This pull request introduces a method channel in native Swift that introduces communication with the Flutter code. It allows for the transmission of a Base64-encoded image, complementing the existing functionality that previously handled images retrieved from native Kotlin for Android, allowing the user to paste images from the clipboard in ios.

## Major Changes
- Updated `ios/Runner/AppDelegate.swift` to manage Base64 encoding and facilitate sending data to the Flutter channel.

## How to Run
1. Navigate to the `ios` folder:
   ```bash
   cd ios
2. Install the necessary CocoaPods:
   ```bash
   pod install
3. Build the project 

## Video demo of the change: 

https://github.com/user-attachments/assets/cbcb75d4-242c-4c9f-a76e-b6a6b6d31767






